### PR TITLE
Add B.Protocol

### DIFF
--- a/contracts/protocols/mainnet/b.protocol/compound/helpers.sol
+++ b/contracts/protocols/mainnet/b.protocol/compound/helpers.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+import { ComptrollerLensInterface, TokenInterface, BCompoundRegistry, BAvatar } from "./interfaces.sol";
+import { DSMath } from "./../../../../utils/dsmath.sol";
+
+contract Helpers is DSMath {
+    /**
+     * @dev get Compound Comptroller
+     */
+    function getComptroller() public pure returns (ComptrollerLensInterface) {
+        return ComptrollerLensInterface(0x3d9819210A31b4961b30EF54bE2aeD79B9c9Cd3B);
+    }
+
+    /**
+     * @dev get Compound Open Feed Oracle Address
+     */
+    function getOracleAddress() public view returns (address) {
+        return getComptroller().oracle();
+    }
+
+    /**
+     * @dev get Comp Read Address
+     */
+    function getCompReadAddress() public pure returns (address) {
+        return 0xd513d22422a3062Bd342Ae374b4b9c20E0a9a074;
+    }
+
+    /**
+     * @dev get ETH Address
+     */
+    function getCETHAddress() public pure returns (address) {
+        return 0x4Ddc2D193948926D02f9B1fE9e1daa0718270ED5;
+    }
+
+    /**
+     * @dev get Comp Token Address
+     */
+    function getCompToken() public pure returns (TokenInterface) {
+        return TokenInterface(0xc00e94Cb662C3520282E6f5717214004A7f26888);
+    }
+
+    /**
+     * @dev get B.Registery Address
+     */
+    function getBRegistery() public pure returns (BCompoundRegistry) {
+        return BCompoundRegistry(0xbF698dF5591CaF546a7E087f5806E216aFED666A);
+    }
+
+    /**
+     * @dev get owner avatar
+     */
+    function getOwnerBAvatar(address owner) public view returns (address) {
+        return getBRegistery().avatarOf(owner);
+    }
+
+    /**
+     * @dev get owner cushion debt
+     */
+    function getOwnerAddtionalDebt(address avatar, address ctoken) public view returns (uint) {
+        if(avatar == address(0)) return 0;
+
+        if(BAvatar(avatar).toppedUpCToken() == ctoken) return BAvatar(avatar).toppedUpAmount();
+        else return 0;
+    }    
+
+    struct CompData {
+        uint256 tokenPriceInEth;
+        uint256 tokenPriceInUsd;
+        uint256 exchangeRateStored;
+        uint256 balanceOfUser;
+        uint256 borrowBalanceStoredUser;
+        uint256 totalBorrows;
+        uint256 totalSupplied;
+        uint256 borrowCap;
+        uint256 supplyRatePerBlock;
+        uint256 borrowRatePerBlock;
+        uint256 collateralFactor;
+        uint256 compSpeed;
+        bool isComped;
+        bool isBorrowPaused;
+    }
+}

--- a/contracts/protocols/mainnet/b.protocol/compound/interfaces.sol
+++ b/contracts/protocols/mainnet/b.protocol/compound/interfaces.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+interface CTokenInterface {
+    function exchangeRateStored() external view returns (uint256);
+
+    function borrowRatePerBlock() external view returns (uint256);
+
+    function supplyRatePerBlock() external view returns (uint256);
+
+    function borrowBalanceStored(address) external view returns (uint256);
+
+    function totalBorrows() external view returns (uint256);
+
+    function underlying() external view returns (address);
+
+    function balanceOf(address) external view returns (uint256);
+
+    function getCash() external view returns (uint256);
+}
+
+interface TokenInterface {
+    function decimals() external view returns (uint256);
+
+    function balanceOf(address) external view returns (uint256);
+}
+
+interface OrcaleComp {
+    function getUnderlyingPrice(address) external view returns (uint256);
+}
+
+interface ComptrollerLensInterface {
+    function markets(address)
+        external
+        view
+        returns (
+            bool,
+            uint256,
+            bool
+        );
+
+    function getAccountLiquidity(address)
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function claimComp(address) external;
+
+    function compAccrued(address) external view returns (uint256);
+
+    function borrowCaps(address) external view returns (uint256);
+
+    function borrowGuardianPaused(address) external view returns (bool);
+
+    function oracle() external view returns (address);
+
+    function compSpeeds(address) external view returns (uint256);
+}
+
+interface CompReadInterface {
+    struct CompBalanceMetadataExt {
+        uint256 balance;
+        uint256 votes;
+        address delegate;
+        uint256 allocated;
+    }
+
+    function getCompBalanceMetadataExt(
+        TokenInterface comp,
+        ComptrollerLensInterface comptroller,
+        address account
+    ) external returns (CompBalanceMetadataExt memory);
+}
+
+interface BCompoundRegistry {
+    function avatarOf(address owner) external view returns (address);
+}
+
+interface BAvatar {
+    function toppedUpCToken() external view returns (address);
+    function toppedUpAmount() external view returns (uint256);
+}

--- a/contracts/protocols/mainnet/b.protocol/compound/main.sol
+++ b/contracts/protocols/mainnet/b.protocol/compound/main.sol
@@ -1,0 +1,60 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+import "./interfaces.sol";
+import "./helpers.sol";
+
+contract Resolver is Helpers {
+    function getPriceInEth(CTokenInterface cToken) public view returns (uint256 priceInETH, uint256 priceInUSD) {
+        uint256 decimals = getCETHAddress() == address(cToken) ? 18 : TokenInterface(cToken.underlying()).decimals();
+        uint256 price = OrcaleComp(getOracleAddress()).getUnderlyingPrice(address(cToken));
+        uint256 ethPrice = OrcaleComp(getOracleAddress()).getUnderlyingPrice(getCETHAddress());
+        priceInUSD = price / 10**(18 - decimals);
+        priceInETH = wdiv(priceInUSD, ethPrice);
+    }
+
+    function getCompoundData(address owner, address[] memory cAddress) public view returns (CompData[] memory) {
+        CompData[] memory tokensData = new CompData[](cAddress.length);
+        ComptrollerLensInterface troller = getComptroller();
+
+        address bavatar = getOwnerBAvatar(owner);
+
+        for (uint256 i = 0; i < cAddress.length; i++) {
+            CTokenInterface cToken = CTokenInterface(cAddress[i]);
+            (uint256 priceInETH, uint256 priceInUSD) = getPriceInEth(cToken);
+            (, uint256 collateralFactor, bool isComped) = troller.markets(address(cToken));
+            uint256 _totalBorrowed = cToken.totalBorrows();
+            tokensData[i] = CompData(
+                priceInETH,
+                priceInUSD,
+                cToken.exchangeRateStored(),
+                cToken.balanceOf(bavatar),
+                cToken.borrowBalanceStored(bavatar) + getOwnerAddtionalDebt(bavatar, address(cToken)),
+                _totalBorrowed,
+                add(_totalBorrowed, cToken.getCash()),
+                troller.borrowCaps(cAddress[i]),
+                cToken.supplyRatePerBlock(),
+                cToken.borrowRatePerBlock(),
+                collateralFactor,
+                troller.compSpeeds(cAddress[i]),
+                isComped,
+                troller.borrowGuardianPaused(cAddress[i])
+            );
+        }
+
+        return tokensData;
+    }
+
+    function getPosition(address owner, address[] memory cAddress)
+        public
+        returns (CompData[] memory, CompReadInterface.CompBalanceMetadataExt memory)
+    {
+        return (
+            getCompoundData(owner, cAddress),
+            CompReadInterface(getCompReadAddress()).getCompBalanceMetadataExt(getCompToken(), getComptroller(), getOwnerBAvatar(owner))
+        );
+    }
+}
+
+contract InstaBCompoundResolver is Resolver {
+    string public constant name = "B.Compound-Resolver-v1.0";
+}

--- a/contracts/protocols/mainnet/b.protocol/maker/helpers.sol
+++ b/contracts/protocols/mainnet/b.protocol/maker/helpers.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+import "./interfaces.sol";
+import { DSMath } from "./../../../../utils/dsmath.sol";
+
+contract Helpers is DSMath {
+    /**
+     * @dev get MakerDAO MCD Address contract
+     */
+    function getMcdAddresses() public pure returns (address) {
+        return 0xF23196DF1C440345DE07feFbe556a5eF0dcD29F0;
+    }
+
+    struct VaultData {
+        uint256 id;
+        address owner;
+        string colType;
+        uint256 collateral;
+        uint256 art;
+        uint256 debt;
+        uint256 liquidatedCol;
+        uint256 borrowRate;
+        uint256 colPrice;
+        uint256 liquidationRatio;
+        address vaultAddress;
+    }
+
+    struct ColInfo {
+        uint256 borrowRate;
+        uint256 price;
+        uint256 liquidationRatio;
+        uint256 vaultDebtCelling;
+        uint256 vaultDebtFloor;
+        uint256 vaultTotalDebt;
+        uint256 totalDebtCelling;
+        uint256 TotalDebt;
+    }
+
+    /**
+     * @dev Convert String to bytes32.
+     */
+    function stringToBytes32(string memory str) internal pure returns (bytes32 result) {
+        require(bytes(str).length != 0, "String-Empty");
+        // solium-disable-next-line security/no-inline-assembly
+        assembly {
+            result := mload(add(str, 32))
+        }
+    }
+
+    /**
+     * @dev Convert bytes32 to String.
+     */
+    function bytes32ToString(bytes32 _bytes32) internal pure returns (string memory) {
+        bytes32 _temp;
+        uint256 count;
+        for (uint256 i; i < 32; i++) {
+            _temp = _bytes32[i];
+            if (_temp != bytes32(0)) {
+                count += 1;
+            }
+        }
+        bytes memory bytesArray = new bytes(count);
+        for (uint256 i; i < count; i++) {
+            bytesArray[i] = (_bytes32[i]);
+        }
+        return (string(bytesArray));
+    }
+
+    function getFee(bytes32 ilk) internal view returns (uint256 fee) {
+        address jug = InstaMcdAddress(getMcdAddresses()).jug();
+        (uint256 duty, ) = JugLike(jug).ilks(ilk);
+        uint256 base = JugLike(jug).base();
+        fee = add(duty, base);
+    }
+
+    function getColPrice(bytes32 ilk) internal view returns (uint256 price) {
+        address spot = InstaMcdAddress(getMcdAddresses()).spot();
+        address vat = InstaMcdAddress(getMcdAddresses()).vat();
+        (, uint256 mat) = SpotLike(spot).ilks(ilk);
+        (, , uint256 spotPrice, , ) = VatLike(vat).ilks(ilk);
+        price = rmul(mat, spotPrice);
+    }
+
+    function getColRatio(bytes32 ilk) internal view returns (uint256 ratio) {
+        address spot = InstaMcdAddress(getMcdAddresses()).spot();
+        (, ratio) = SpotLike(spot).ilks(ilk);
+    }
+
+    function getDebtFloorAndCeiling(bytes32 ilk)
+        internal
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256
+        )
+    {
+        address vat = InstaMcdAddress(getMcdAddresses()).vat();
+        (uint256 totalArt, uint256 rate, , uint256 vaultDebtCellingRad, uint256 vaultDebtFloor) =
+            VatLike(vat).ilks(ilk);
+        uint256 vaultDebtCelling = vaultDebtCellingRad / 10**45;
+        uint256 vaultTotalDebt = rmul(totalArt, rate);
+
+        uint256 totalDebtCelling = VatLike(vat).Line();
+        uint256 totalDebt = VatLike(vat).debt();
+        return (vaultDebtCelling, vaultTotalDebt, vaultDebtFloor, totalDebtCelling, totalDebt);
+    }
+}

--- a/contracts/protocols/mainnet/b.protocol/maker/helpers.sol
+++ b/contracts/protocols/mainnet/b.protocol/maker/helpers.sol
@@ -11,6 +11,10 @@ contract Helpers is DSMath {
         return 0xF23196DF1C440345DE07feFbe556a5eF0dcD29F0;
     }
 
+    function getManager() public pure returns (BManagerLike) {
+        return BManagerLike(0x3f30c2381CD8B917Dd96EB2f1A4F96D91324BBed);
+    }
+
     struct VaultData {
         uint256 id;
         address owner;
@@ -106,5 +110,9 @@ contract Helpers is DSMath {
         uint256 totalDebtCelling = VatLike(vat).Line();
         uint256 totalDebt = VatLike(vat).debt();
         return (vaultDebtCelling, vaultTotalDebt, vaultDebtFloor, totalDebtCelling, totalDebt);
+    }
+
+    function getAddtionalDebt(uint256 id) internal view returns(uint256) {
+        return getManager().cushion(id);
     }
 }

--- a/contracts/protocols/mainnet/b.protocol/maker/interfaces.sol
+++ b/contracts/protocols/mainnet/b.protocol/maker/interfaces.sol
@@ -11,6 +11,10 @@ interface ManagerLike {
     function vat() external view returns (address);
 }
 
+interface BManagerLike is ManagerLike {
+    function cushion(uint256) external view returns (uint256);
+}
+
 interface CdpsLike {
     function getCdpsAsc(address, address)
         external

--- a/contracts/protocols/mainnet/b.protocol/maker/interfaces.sol
+++ b/contracts/protocols/mainnet/b.protocol/maker/interfaces.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+
+interface ManagerLike {
+    function ilks(uint256) external view returns (bytes32);
+
+    function owns(uint256) external view returns (address);
+
+    function urns(uint256) external view returns (address);
+
+    function vat() external view returns (address);
+}
+
+interface CdpsLike {
+    function getCdpsAsc(address, address)
+        external
+        view
+        returns (
+            uint256[] memory,
+            address[] memory,
+            bytes32[] memory
+        );
+}
+
+interface VatLike {
+    function ilks(bytes32)
+        external
+        view
+        returns (
+            uint256,
+            uint256,
+            uint256,
+            uint256,
+            uint256
+        );
+
+    function dai(address) external view returns (uint256);
+
+    function urns(bytes32, address) external view returns (uint256, uint256);
+
+    function gem(bytes32, address) external view returns (uint256);
+
+    function debt() external view returns (uint256);
+
+    function Line() external view returns (uint256);
+}
+
+interface JugLike {
+    function ilks(bytes32) external view returns (uint256, uint256);
+
+    function base() external view returns (uint256);
+}
+
+interface PotLike {
+    function dsr() external view returns (uint256);
+
+    function pie(address) external view returns (uint256);
+
+    function chi() external view returns (uint256);
+}
+
+interface SpotLike {
+    function ilks(bytes32) external view returns (PipLike, uint256);
+}
+
+interface PipLike {
+    function peek() external view returns (bytes32, bool);
+}
+
+interface InstaMcdAddress {
+    function manager() external view returns (address);
+
+    function vat() external view returns (address);
+
+    function jug() external view returns (address);
+
+    function spot() external view returns (address);
+
+    function pot() external view returns (address);
+
+    function getCdps() external view returns (address);
+}

--- a/contracts/protocols/mainnet/b.protocol/maker/main.sol
+++ b/contracts/protocols/mainnet/b.protocol/maker/main.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.8.0;
+import "./interfaces.sol";
+import "./helpers.sol";
+
+contract VaultResolver is Helpers {
+    function getVaults(address owner) external view returns (VaultData[] memory) {
+        address manager = InstaMcdAddress(getMcdAddresses()).manager();
+        address cdpManger = InstaMcdAddress(getMcdAddresses()).getCdps();
+
+        (uint256[] memory ids, address[] memory urns, bytes32[] memory ilks) =
+            CdpsLike(cdpManger).getCdpsAsc(manager, owner);
+        VaultData[] memory vaults = new VaultData[](ids.length);
+
+        for (uint256 i = 0; i < ids.length; i++) {
+            (uint256 ink, uint256 art) = VatLike(ManagerLike(manager).vat()).urns(ilks[i], urns[i]);
+            (, uint256 rate, uint256 priceMargin, , ) = VatLike(ManagerLike(manager).vat()).ilks(ilks[i]);
+            uint256 mat = getColRatio(ilks[i]);
+
+            vaults[i] = VaultData(
+                ids[i],
+                owner,
+                bytes32ToString(ilks[i]),
+                ink,
+                art,
+                rmul(art, rate),
+                VatLike(ManagerLike(manager).vat()).gem(ilks[i], urns[i]),
+                getFee(ilks[i]),
+                rmul(priceMargin, mat),
+                mat,
+                urns[i]
+            );
+        }
+        return vaults;
+    }
+
+    function getVaultById(uint256 id) external view returns (VaultData memory) {
+        address manager = InstaMcdAddress(getMcdAddresses()).manager();
+        address urn = ManagerLike(manager).urns(id);
+        bytes32 ilk = ManagerLike(manager).ilks(id);
+
+        (uint256 ink, uint256 art) = VatLike(ManagerLike(manager).vat()).urns(ilk, urn);
+        (, uint256 rate, uint256 priceMargin, , ) = VatLike(ManagerLike(manager).vat()).ilks(ilk);
+
+        uint256 mat = getColRatio(ilk);
+
+        uint256 feeRate = getFee(ilk);
+        VaultData memory vault =
+            VaultData(
+                id,
+                ManagerLike(manager).owns(id),
+                bytes32ToString(ilk),
+                ink,
+                art,
+                rmul(art, rate),
+                VatLike(ManagerLike(manager).vat()).gem(ilk, urn),
+                feeRate,
+                rmul(priceMargin, mat),
+                mat,
+                urn
+            );
+        return vault;
+    }
+
+    function getColInfo(string[] memory name) public view returns (ColInfo[] memory) {
+        ColInfo[] memory colInfo = new ColInfo[](name.length);
+
+        for (uint256 i = 0; i < name.length; i++) {
+            bytes32 ilk = stringToBytes32(name[i]);
+            (
+                uint256 vaultDebtCelling,
+                uint256 vaultDebtFloor,
+                uint256 vaultTotalDebt,
+                uint256 totalDebtCelling,
+                uint256 totalDebt
+            ) = getDebtFloorAndCeiling(ilk);
+
+            colInfo[i] = ColInfo(
+                getFee(ilk),
+                getColPrice(ilk),
+                getColRatio(ilk),
+                vaultDebtCelling,
+                vaultTotalDebt,
+                vaultDebtFloor,
+                totalDebtCelling,
+                totalDebt
+            );
+        }
+        return colInfo;
+    }
+}
+
+contract DSRResolver is VaultResolver {
+    function getDsrRate() public view returns (uint256 dsr) {
+        address pot = InstaMcdAddress(getMcdAddresses()).pot();
+        dsr = PotLike(pot).dsr();
+    }
+
+    function getDaiPosition(address owner) external view returns (uint256 amt, uint256 dsr) {
+        address pot = InstaMcdAddress(getMcdAddresses()).pot();
+        uint256 chi = PotLike(pot).chi();
+        uint256 pie = PotLike(pot).pie(owner);
+        amt = rmul(pie, chi);
+        dsr = getDsrRate();
+    }
+}
+
+contract InstaMakerResolver is DSRResolver {
+    string public constant name = "Maker-Resolver-v1.4";
+}

--- a/contracts/protocols/mainnet/b.protocol/maker/main.sol
+++ b/contracts/protocols/mainnet/b.protocol/maker/main.sol
@@ -5,7 +5,7 @@ import "./helpers.sol";
 
 contract VaultResolver is Helpers {
     function getVaults(address owner) external view returns (VaultData[] memory) {
-        address manager = InstaMcdAddress(getMcdAddresses()).manager();
+        address manager = address(getManager());
         address cdpManger = InstaMcdAddress(getMcdAddresses()).getCdps();
 
         (uint256[] memory ids, address[] memory urns, bytes32[] memory ilks) =
@@ -14,6 +14,7 @@ contract VaultResolver is Helpers {
 
         for (uint256 i = 0; i < ids.length; i++) {
             (uint256 ink, uint256 art) = VatLike(ManagerLike(manager).vat()).urns(ilks[i], urns[i]);
+            art = add(art, getAddtionalDebt(ids[i]));
             (, uint256 rate, uint256 priceMargin, , ) = VatLike(ManagerLike(manager).vat()).ilks(ilks[i]);
             uint256 mat = getColRatio(ilks[i]);
 
@@ -35,11 +36,12 @@ contract VaultResolver is Helpers {
     }
 
     function getVaultById(uint256 id) external view returns (VaultData memory) {
-        address manager = InstaMcdAddress(getMcdAddresses()).manager();
+        address manager = address(getManager());
         address urn = ManagerLike(manager).urns(id);
         bytes32 ilk = ManagerLike(manager).ilks(id);
 
         (uint256 ink, uint256 art) = VatLike(ManagerLike(manager).vat()).urns(ilk, urn);
+        art = add(art, getAddtionalDebt(id));
         (, uint256 rate, uint256 priceMargin, , ) = VatLike(ManagerLike(manager).vat()).ilks(ilk);
 
         uint256 mat = getColRatio(ilk);
@@ -105,6 +107,6 @@ contract DSRResolver is VaultResolver {
     }
 }
 
-contract InstaMakerResolver is DSRResolver {
-    string public constant name = "Maker-Resolver-v1.4";
+contract InstaBMakerResolver is DSRResolver {
+    string public constant name = "B.Maker-Resolver-v1.0";
 }

--- a/test/consts.ts
+++ b/test/consts.ts
@@ -17,4 +17,9 @@ export const Tokens: TokensObject = {
     decimals: 6,
     caddr: "0x39aa39c021dfbae8fac545936693ac917d5e7563",
   },
+  WBTC: {
+    addr: "0x2260FAC5E5542a773Aa44fBCfeDf7C193bc2C599",
+    decimals: 8,
+    caddr: "0xccf4429db6322d5c611ee964527d42e5d685dd6a",
+  },  
 };

--- a/test/mainnet/b.protocol/compound.test.ts
+++ b/test/mainnet/b.protocol/compound.test.ts
@@ -5,7 +5,7 @@ import { ethers } from "hardhat";
 import { InstaBCompoundResolver, InstaBCompoundResolver__factory } from "../../../typechain";
 import { Tokens } from "../../consts";
 
-describe("Compound Resolvers", () => {
+describe("B.Compound Resolvers", () => {
   let signer: SignerWithAddress;
   const account = "0xf7D44D5a28d5AF27a7F9c8fc6eFe0129e554d7c4";
 
@@ -13,7 +13,7 @@ describe("Compound Resolvers", () => {
     [signer] = await ethers.getSigners();
   });
 
-  describe("Compound Resolver", () => {
+  describe("B.Compound Resolver", () => {
     let resolver: InstaBCompoundResolver;
     before(async () => {
       const deployer = new InstaBCompoundResolver__factory(signer);

--- a/test/mainnet/b.protocol/compound.test.ts
+++ b/test/mainnet/b.protocol/compound.test.ts
@@ -1,0 +1,42 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { formatEther, formatUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+import { InstaBCompoundResolver, InstaBCompoundResolver__factory } from "../../../typechain";
+import { Tokens } from "../../consts";
+
+describe("Compound Resolvers", () => {
+  let signer: SignerWithAddress;
+  const account = "0xf7D44D5a28d5AF27a7F9c8fc6eFe0129e554d7c4";
+
+  before(async () => {
+    [signer] = await ethers.getSigners();
+  });
+
+  describe("Compound Resolver", () => {
+    let resolver: InstaBCompoundResolver;
+    before(async () => {
+      const deployer = new InstaBCompoundResolver__factory(signer);
+      resolver = await deployer.deploy();
+      await resolver.deployed();
+    });
+
+    it("Returns the price of cToken's underlying in ETH", async () => {
+      const [priceInETH, priceInUSD] = await resolver.getPriceInEth(Tokens.DAI.caddr);
+      console.log("DAI price in ETH: ", formatEther(priceInETH));
+      console.log("DAI price in USD: ", formatEther(priceInUSD));
+      expect(priceInETH).to.gt(0);
+      expect(priceInUSD).to.gt(0);
+    });
+
+    it("Returns the positions correctly", async () => {
+      const [daiData, wbtcData] = await resolver.getCompoundData(account, [Tokens.DAI.caddr, Tokens.WBTC.caddr]);
+
+      console.log("WBTC Balance: ", formatUnits(wbtcData.balanceOfUser, 8));
+      expect(wbtcData.balanceOfUser).to.gt(0);
+
+      console.log("DAI borrow balance: ", formatEther(daiData.borrowBalanceStoredUser));
+      expect(daiData.borrowBalanceStoredUser).to.gt(0);
+    });
+  });
+});

--- a/test/mainnet/b.protocol/maker.test.ts
+++ b/test/mainnet/b.protocol/maker.test.ts
@@ -3,7 +3,7 @@ import { expect } from "chai";
 import { ethers } from "hardhat";
 import { InstaBMakerResolver, InstaBMakerResolver__factory } from "../../../typechain";
 
-describe("Maker Resolvers", () => {
+describe("B.Maker Resolvers", () => {
   let signer: SignerWithAddress;
   const account = "0x9788A89a055d727E737dE733e7D1D01D99FCD542";
 
@@ -11,7 +11,7 @@ describe("Maker Resolvers", () => {
     [signer] = await ethers.getSigners();
   });
 
-  describe("Maker Resolver", () => {
+  describe("B.Maker Resolver", () => {
     let resolver: InstaBMakerResolver;
 
     before(async () => {
@@ -36,55 +36,3 @@ describe("Maker Resolvers", () => {
     });
   });
 });
-
-/*
-struct VaultData {
-  uint256 id;
-  address owner;
-  string colType;
-  uint256 collateral;
-  uint256 art;
-  uint256 debt;
-  uint256 liquidatedCol;
-  uint256 borrowRate;
-  uint256 colPrice;
-  uint256 liquidationRatio;
-  address vaultAddress;
-}
-[
-  {
-    "type": "BigNumber",
-    "hex": "0xbc"
-  },
-  "0x9788A89a055d727E737dE733e7D1D01D99FCD542",
-  "ETH-A",
-  {
-    "type": "BigNumber",
-    "hex": "0x0163a06b6e044000"
-  },
-  {
-    "type": "BigNumber",
-    "hex": "0x00"
-  },
-  {
-    "type": "BigNumber",
-    "hex": "0x00"
-  },
-  {
-    "type": "BigNumber",
-    "hex": "0x00"
-  },
-  {
-    "type": "BigNumber",
-    "hex": "0x033b2e3cb7602df349e89c05"
-  },
-  {
-    "type": "BigNumber",
-    "hex": "0x1e2ff7996797c21156ca000000"
-  },
-  {
-    "type": "BigNumber",
-    "hex": "0x04d8c55aefb8c05b5c000000"
-  },
-  "0x68C3883439A22018d11F423740037CbaBA595593"
-]*/

--- a/test/mainnet/b.protocol/maker.test.ts
+++ b/test/mainnet/b.protocol/maker.test.ts
@@ -1,0 +1,90 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { ethers } from "hardhat";
+import { InstaBMakerResolver, InstaBMakerResolver__factory } from "../../../typechain";
+
+describe("Maker Resolvers", () => {
+  let signer: SignerWithAddress;
+  const account = "0x9788A89a055d727E737dE733e7D1D01D99FCD542";
+
+  before(async () => {
+    [signer] = await ethers.getSigners();
+  });
+
+  describe("Maker Resolver", () => {
+    let resolver: InstaBMakerResolver;
+
+    before(async () => {
+      const deployer = new InstaBMakerResolver__factory(signer);
+      resolver = await deployer.deploy();
+    });
+
+    it("returns the vault info properly", async () => {
+      const res = await resolver.getVaults(account);
+
+      expect(res.length).to.be.equal(1);
+      const vault = res[0];
+
+      expect(vault[0]).to.be.equal("0xbc"); // id
+      expect(vault[1]).to.be.equal(account); // owner
+      expect(vault[2]).to.be.equal("ETH-A"); // collateral type 
+      expect(vault[3]).to.be.equal("0x0163a06b6e044000"); // collateral 0.1001 ETH
+      expect(vault[4]).to.be.equal("0"); // art
+      
+      const singleRes = await resolver.getVaultById(0xbc);
+      expect(JSON.stringify(singleRes)).to.be.equal(JSON.stringify(res[0]));
+    });
+  });
+});
+
+/*
+struct VaultData {
+  uint256 id;
+  address owner;
+  string colType;
+  uint256 collateral;
+  uint256 art;
+  uint256 debt;
+  uint256 liquidatedCol;
+  uint256 borrowRate;
+  uint256 colPrice;
+  uint256 liquidationRatio;
+  address vaultAddress;
+}
+[
+  {
+    "type": "BigNumber",
+    "hex": "0xbc"
+  },
+  "0x9788A89a055d727E737dE733e7D1D01D99FCD542",
+  "ETH-A",
+  {
+    "type": "BigNumber",
+    "hex": "0x0163a06b6e044000"
+  },
+  {
+    "type": "BigNumber",
+    "hex": "0x00"
+  },
+  {
+    "type": "BigNumber",
+    "hex": "0x00"
+  },
+  {
+    "type": "BigNumber",
+    "hex": "0x00"
+  },
+  {
+    "type": "BigNumber",
+    "hex": "0x033b2e3cb7602df349e89c05"
+  },
+  {
+    "type": "BigNumber",
+    "hex": "0x1e2ff7996797c21156ca000000"
+  },
+  {
+    "type": "BigNumber",
+    "hex": "0x04d8c55aefb8c05b5c000000"
+  },
+  "0x68C3883439A22018d11F423740037CbaBA595593"
+]*/


### PR DESCRIPTION
Protocol: https://bprotocol.org

This connector adds support for interacting with Maker and Compound via B.Protocol smart contract.
Users can do everything the can do with Maker and Compound and get exactly the same conditions, and in addition get to share liquidation proceeds, and when applicable B.Protocol governance tokens.

The implementation is a simple clone of the Compound and Maker connectors, with small adaptations to the B.Protocol system.
1. Using different addresses for CDP manager, and comptroller.
2. Adjusting the user debt report, to include the debt that might have been partially paid by the B.Protocol liquidators.