### PR TITLE
Added functions to get rewards data, handled Avax and Qi rewards separately

### DIFF
--- a/contracts/protocols/avalanche/benqi/helpers.sol
+++ b/contracts/protocols/avalanche/benqi/helpers.sol
@@ -49,6 +49,7 @@ contract Helpers is DSMath {
         bool isQied;
         bool isBorrowPaused;
     }
+
     struct MetadataExt {
         uint256 avaxAccrued;
         uint256 qiAccrued;

--- a/contracts/protocols/avalanche/benqi/helpers.sol
+++ b/contracts/protocols/avalanche/benqi/helpers.sol
@@ -44,8 +44,13 @@ contract Helpers is DSMath {
         uint256 supplyRatePerTimestamp;
         uint256 borrowRatePerTimestamp;
         uint256 collateralFactor;
-        uint256 rewardSpeed;
+        uint256 rewardSpeedQi;
+        uint256 rewardSpeedAvax;
         bool isQied;
         bool isBorrowPaused;
+    }
+    struct MetadataExt {
+        uint256 avaxAccrued;
+        uint256 qiAccrued;
     }
 }

--- a/contracts/protocols/avalanche/benqi/helpers.sol
+++ b/contracts/protocols/avalanche/benqi/helpers.sol
@@ -52,5 +52,7 @@ contract Helpers is DSMath {
     struct MetadataExt {
         uint256 avaxAccrued;
         uint256 qiAccrued;
+        address delegate;
+        uint96 votes;
     }
 }

--- a/contracts/protocols/avalanche/benqi/interfaces.sol
+++ b/contracts/protocols/avalanche/benqi/interfaces.sol
@@ -23,6 +23,10 @@ interface TokenInterface {
     function decimals() external view returns (uint256);
 
     function balanceOf(address) external view returns (uint256);
+
+    function delegates(address) external view returns (address);
+
+    function getCurrentVotes(address) external view returns (uint96);
 }
 
 interface OrcaleQi {

--- a/contracts/protocols/avalanche/benqi/main.sol
+++ b/contracts/protocols/avalanche/benqi/main.sol
@@ -48,12 +48,18 @@ contract Resolver is Helpers {
         return tokensData;
     }
 
-    function getRewardsData(address owner, ComptrollerLensInterface comptroller)
-        public
-        view
-        returns (MetadataExt memory)
-    {
-        return MetadataExt(comptroller.rewardAccrued(0, owner), comptroller.rewardAccrued(1, owner));
+    function getRewardsData(
+        address owner,
+        ComptrollerLensInterface comptroller,
+        TokenInterface qiToken
+    ) public view returns (MetadataExt memory) {
+        return
+            MetadataExt(
+                comptroller.rewardAccrued(0, owner),
+                comptroller.rewardAccrued(1, owner),
+                qiToken.delegates(owner),
+                qiToken.getCurrentVotes(owner)
+            );
     }
 
     function getPosition(address owner, address[] memory qiAddress)
@@ -61,7 +67,7 @@ contract Resolver is Helpers {
         view
         returns (BenqiData[] memory, MetadataExt memory)
     {
-        return (getBenqiData(owner, qiAddress), getRewardsData(owner, getComptroller()));
+        return (getBenqiData(owner, qiAddress), getRewardsData(owner, getComptroller(), getQiToken()));
     }
 }
 

--- a/contracts/protocols/avalanche/benqi/main.sol
+++ b/contracts/protocols/avalanche/benqi/main.sol
@@ -39,12 +39,29 @@ contract Resolver is Helpers {
                 qiToken.borrowRatePerTimestamp(),
                 collateralFactor,
                 troller.rewardSpeeds(rewardQi, qiAddress[i]),
+                troller.rewardSpeeds(rewardAvax, qiAddress[i]),
                 isQied,
                 troller.borrowGuardianPaused(qiAddress[i])
             );
         }
 
         return tokensData;
+    }
+
+    function getRewardsData(address owner, ComptrollerLensInterface comptroller)
+        public
+        view
+        returns (MetadataExt memory)
+    {
+        return MetadataExt(comptroller.rewardAccrued(0, owner), comptroller.rewardAccrued(1, owner));
+    }
+
+    function getPosition(address owner, address[] memory qiAddress)
+        public
+        view
+        returns (BenqiData[] memory, MetadataExt memory)
+    {
+        return (getBenqiData(owner, qiAddress), getRewardsData(owner, getComptroller()));
     }
 }
 


### PR DESCRIPTION
This PR makes new functions in the resolver which return the data related to the rewards(both Qi and Avax) along with the individual token data.