### PR TITLE
Fix code to create child processes

### DIFF
--- a/scripts/command.ts
+++ b/scripts/command.ts
@@ -1,0 +1,33 @@
+import { execFile, spawn } from "child_process";
+
+interface ICommand {
+  readonly cmd: string;
+  readonly args: string[];
+  readonly env: {
+    [param: string]: string;
+  };
+}
+
+export async function execScript(input: ICommand): Promise<number> {
+  return new Promise((resolve, reject) => {
+    let cmdEnv = Object.create(process.env);
+    for (let param in input.env) {
+      cmdEnv[param] = input.env[param];
+    }
+
+    const proc = spawn(input.cmd, [...input.args], {
+      env: cmdEnv,
+      shell: true,
+      stdio: "inherit",
+    });
+
+    proc.on("exit", code => {
+      if (code !== 0) {
+        reject(code);
+        return;
+      }
+
+      resolve(code);
+    });
+  });
+}

--- a/scripts/global-test.ts
+++ b/scripts/global-test.ts
@@ -1,0 +1,30 @@
+import inquirer from "inquirer";
+import { promises as fs } from "fs";
+import { join } from "path";
+import { execScript } from "./command";
+
+async function testRunner() {
+  const chain = ["avalanche", "mainnet", "polygon"];
+  for (let ch of chain) {
+    console.log(`📗Running test for %c${ch}: `, "blue");
+    let path: string;
+    const testsPath = join(__dirname, "../test", ch);
+    await fs.access(testsPath);
+    const availableTests = await fs.readdir(testsPath);
+    if (availableTests.length !== 0) {
+      path = availableTests.map(file => join(testsPath, file)).join(" ");
+
+      await execScript({
+        cmd: "npx",
+        args: ["hardhat", "test", path],
+        env: {
+          networkType: ch,
+        },
+      });
+    }
+  }
+}
+
+testRunner()
+  .then(() => console.log("🙌 finished the test runner"))
+  .catch(err => console.error("❌ failed due to error: ", err));

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -1,23 +1,7 @@
 import inquirer from "inquirer";
 import { promises as fs } from "fs";
-import { join } from "path/posix";
-import { spawn } from "child_process";
-import { assert } from "chai";
-
-export async function execScript(cmd: string): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const parts = cmd.split(" ");
-    const proc = spawn(parts[0], parts.slice(1), { shell: true, stdio: "inherit" });
-    proc.on("exit", code => {
-      if (code !== 0) {
-        reject(code);
-        return;
-      }
-
-      resolve(code);
-    });
-  });
-}
+import { join } from "path";
+import { execScript } from "./command";
 
 async function testRunner() {
   let currentNetwork = String(network.name);
@@ -59,7 +43,13 @@ async function testRunner() {
     path = join(testsPath, testName);
   }
 
-  await execScript("npx hardhat test " + path);
+  await execScript({
+    cmd: "npx",
+    args: ["hardhat", "test", path],
+    env: {
+      networkType: chain,
+    },
+  });
 }
 
 testRunner()


### PR DESCRIPTION
This PR primarily fixes how we create child processes in tests.


1. Moves from a posix specific API to a general API to join file paths.
2. Pass the parameters required to start a process properly. This fixes some subtle bugs that you may have encountered if for example your username had a space. 