### PR TITLE
feat: added aave_v2 polygon test + minor fixes

### DIFF
--- a/contracts/protocols/mainnet/aave_v2/helpers.sol
+++ b/contracts/protocols/mainnet/aave_v2/helpers.sol
@@ -47,7 +47,7 @@ contract AaveHelpers is DSMath {
      * @dev Aave Incentives address
      */
     function getAaveIncentivesAddress() internal pure returns (address) {
-        return 0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5; // polygon mainnet
+        return 0xd784927Ff2f95ba542BfC824c8a8a98F3495f6b5; // mainnet
     }
 
     struct AaveUserTokenData {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -24,6 +24,7 @@ const chainIds = {
   rinkeby: 4,
   ropsten: 3,
   avalanche: 43114,
+  polygon: 137,
 };
 
 // Ensure that we have all the environment variables we need.
@@ -129,7 +130,7 @@ const config: HardhatUserConfig = {
     target: "ethers-v5",
   },
   mocha: {
-    timeout: 100 * 1000,
+    timeout: 10000 * 1000,
   },
 };
 

--- a/scripts/global-test.ts
+++ b/scripts/global-test.ts
@@ -1,17 +1,21 @@
-import inquirer from "inquirer";
 import { promises as fs } from "fs";
 
 import { join } from "path";
 import { execScript } from "./command";
 
+let start: number, end: number;
+
 async function testRunner() {
   const chain = ["avalanche", "mainnet", "polygon"];
+  start = Date.now();
+
   for (let ch of chain) {
     console.log(`📗Running test for %c${ch}: `, "blue");
     let path: string;
     const testsPath = join(__dirname, "../test", ch);
     await fs.access(testsPath);
     const availableTests = await fs.readdir(testsPath);
+
     if (availableTests.length !== 0) {
       path = availableTests.map(file => join(testsPath, file)).join(" ");
 
@@ -22,11 +26,12 @@ async function testRunner() {
           networkType: ch,
         },
       });
-
     }
   }
+
+  end = Date.now();
 }
 
 testRunner()
-  .then(() => console.log("🙌 finished the test runner"))
+  .then(() => console.log(`🙌 finished running the test, total time taken ${(end - start) / 1000} sec`))
   .catch(err => console.error("❌ failed due to error: ", err));

--- a/scripts/run-tests.ts
+++ b/scripts/run-tests.ts
@@ -4,6 +4,8 @@ import { promises as fs } from "fs";
 import { join } from "path";
 import { execScript } from "./command";
 
+let start: number, end: number;
+
 async function testRunner() {
   const { chain } = await inquirer.prompt([
     {
@@ -13,7 +15,6 @@ async function testRunner() {
       choices: ["mainnet", "polygon", "avalanche"],
     },
   ]);
-
   const testsPath = join(__dirname, "../test", chain);
   await fs.access(testsPath);
   const availableTests = await fs.readdir(testsPath);
@@ -29,7 +30,7 @@ async function testRunner() {
       choices: ["all", ...availableTests],
     },
   ]);
-
+  start = Date.now();
   let path: string;
   if (testName === "all") {
     path = availableTests.map(file => join(testsPath, file)).join(" ");
@@ -44,8 +45,9 @@ async function testRunner() {
       networkType: chain,
     },
   });
+  end = Date.now();
 }
 
 testRunner()
-  .then(() => console.log("🙌 finished the test runner"))
+  .then(() => console.log(`🙌 finished the test runner, time taken ${(end - start) / 1000} sec`))
   .catch(err => console.error("❌ failed due to error: ", err));

--- a/test/polygon/aave_v2.test.ts
+++ b/test/polygon/aave_v2.test.ts
@@ -1,0 +1,48 @@
+import { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+import { expect } from "chai";
+import { formatUnits } from "ethers/lib/utils";
+import { ethers } from "hardhat";
+import { InstaAaveV2ResolverPolygon, InstaAaveV2ResolverPolygon__factory } from "../../typechain";
+import { Tokens } from "../consts";
+
+describe("Aave V2 Resolvers", () => {
+  let signer: SignerWithAddress;
+  const account = "0x697F5736eE44454fD1Ab614d9fAB237BD1FDB25C";
+
+  before(async () => {
+    [signer] = await ethers.getSigners();
+  });
+
+  describe("Aave V2 Resolver", () => {
+    let resolver: InstaAaveV2ResolverPolygon;
+    before(async () => {
+      const deployer = new InstaAaveV2ResolverPolygon__factory(signer);
+      resolver = await deployer.deploy();
+      await resolver.deployed();
+    });
+
+    it("Should Deploy Successfully", async () => {
+      console.log("Deployed !!");
+    });
+
+    it("Returns the positions on AaveV2", async () => {
+      const daiAddr = "0x8f3cf7ad23cd3cadbd9735aff958023239c6a063";
+      const results = await resolver.getPosition(account, [daiAddr]);
+      const userTokenData = results[0];
+      const userData = results[1];
+
+      // check for token balances
+      console.log("Supply Balance DAI: ", formatUnits(userTokenData[0].supplyBalance, Tokens.DAI.decimals));
+      expect(userTokenData[0].supplyBalance).to.gte(0);
+      console.log(
+        "Variable Borrow Balance DAI: ",
+        formatUnits(userTokenData[0].variableBorrowBalance, Tokens.DAI.decimals),
+      );
+      expect(userTokenData[0].variableBorrowBalance).to.gte(0);
+
+      // check for user data
+      expect(userData.totalBorrowsETH).to.gte(0);
+      expect(userData.totalCollateralETH).to.gte(0);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds aave_v2 testing for polygon chain + some minor fixes.

to run polygon test:
- `npm run test:runner`
- select polygon as a network.
- select the test you want to run. For this case, select `aave_v2.test.ts`.
- Let the game begin.

