### PR TITLE
fix: uniswap test

### DIFF
--- a/contracts/protocols/mainnet/uniswap/main.sol
+++ b/contracts/protocols/mainnet/uniswap/main.sol
@@ -155,7 +155,7 @@ contract Resolver is Helpers {
         (amount0, amount1, amount0Min, amount1Min) = withdrawAmount(tokenId, liquidity, slippage);
     }
 
-    function getCollectAmount(uint256 tokenId) public returns (uint256 amountA, uint256 amountB) {
+    function getCollectAmount(uint256 tokenId) public view returns (uint256 amountA, uint256 amountB) {
         (amountA, amountB) = collectInfo(tokenId);
     }
 


### PR DESCRIPTION
This PR tries to solve the failing uniswap mainnet test.
The changes include adding the `view` keyword to the function `getCollectAmount` in `main.sol` as we read the blockchain state, not making any transaction.

To run the test:
- run `npm run test:runner`
- select `mainnet` as the chain.
- select `uniswap.test.ts` as a test.
- Hakuna Matata.